### PR TITLE
sha256id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ fastlane/test_output
 
 # Test
 .test/
+
+#Ds_Store
+.Ds_Store

--- a/Sources/BlockSet/Cas.swift
+++ b/Sources/BlockSet/Cas.swift
@@ -2,7 +2,12 @@ import Foundation
 import Crypto
 
 public protocol Cas {
+    func id(_ data: Data) -> String
     mutating func add(_ data: Data) throws -> String
     func get(_ id: String) throws -> Data?
     func list() throws -> AnySequence<String>
+}
+
+func sha256Id(_ data: Data) -> String {
+    SHA256.hash(data: data).base32()
 }

--- a/Sources/BlockSet/FileCas.swift
+++ b/Sources/BlockSet/FileCas.swift
@@ -17,8 +17,12 @@ public struct FileCas: Cas {
         self.dir = dir
     }
 
+    public func id(_ data: Data) -> String {
+        sha256Id(data)
+    }
+
     public mutating func add(_ data: Data) throws -> String {
-        let id = SHA256.hash(data: data).base32()
+        let id = id(data)
         try data.write(to: path(id))
         return id
     }

--- a/Sources/BlockSet/MemCas.swift
+++ b/Sources/BlockSet/MemCas.swift
@@ -6,8 +6,12 @@ public struct MemCas: Cas {
 
     public init() {}
 
+    public func id(_ data: Data) -> String {
+        sha256Id(data)
+    }
+
     public mutating func add(_ data: Data) -> String {
-        let id = SHA256.hash(data: data).base32()
+        let id = id(data)
         blocks[id] = data
         return id
     }

--- a/Tests/BlockSetTests/BlockSetTests.swift
+++ b/Tests/BlockSetTests/BlockSetTests.swift
@@ -17,7 +17,9 @@ import Testing
 @Test func memCas() async throws {
     var memCas: Cas = MemCas()
     let data = Data([0, 1, 2, 3])
+    let hash = memCas.id(data)
     let id = try memCas.add(data)
+    #expect(id == hash)
     #expect(try memCas.get(id) == data)
     #expect(try memCas.get("nonexistent") == nil)
     #expect(try memCas.list().contains(id))


### PR DESCRIPTION
 - Add sha256Id as a static function, add id func to CasProtocol.
 - FileCas and MemCas can return String for Data without adding inside the memory.